### PR TITLE
always stop heartbeats when connecting

### DIFF
--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -501,6 +501,8 @@ ConsumerGroup.prototype.connect = function () {
   var self = this;
 
   this.connecting = true;
+  this.stopHeartbeats();
+
   this.emit('rebalancing');
 
   async.waterfall(

--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -668,14 +668,6 @@ ConsumerGroup.prototype.sendHeartbeat = function () {
     if (error) {
       logger.warn('%s Heartbeat error:', self.client.clientId, error);
 
-      // If a rebalance is in progress, stop sending heartbeats with the now
-      // old generationId.
-      //
-      // Completion of the rebalance will restart the heartbeats.
-      if (error instanceof RebalanceInProgress) {
-        self.stopHeartbeats();
-      }
-
       self.recovery.tryToRecoverFrom(error, 'heartbeat');
     }
     // logger.debug('%s 💚 <-', self.client.clientId, error);


### PR DESCRIPTION
This seems to fix the rebalance loop getting entered due to the following sequence of events

```
1. next heartbeat is currently scheduled
2. connect is called outside heartbeat loop (due to socket closed etc)
3. next heartbeat happens with rebalance error because of current reconnect
4. another reconnect is scheduled due to heartbeat error
5. first connect finishes
6. heartbeat interval is cleared and restarted
7. next heartbeat succeeds on the latest generation id
8. scheduled reconnect occurrs from previous heartbeat failure (outside context of current heartbeat loop, ie. from the old generation id)
GOTO 3.
```